### PR TITLE
retry accessing logdir if it is not accessible due to NFS issues

### DIFF
--- a/common_sls.py
+++ b/common_sls.py
@@ -129,8 +129,14 @@ def GetVars(filename='sls_config'):
 		return None
 	return ltp_variables	
 
-def lg(logfile,data,tostdout=1, timestamp=0):
+def lg(logfile, data, tostdout=1, timestamp=0):
 	logdir = "/".join(logfile.split('/')[0:-1])
+	while logdir is None:
+		time.sleep(20)
+		logdir = "/".join(logfile.split('/')[0:-1])
+		if logdir is not None:
+			break
+		print("logdir is None, LOGS NFS issue")
 	if not os.path.exists(logdir):
 		print ("%s directory does not exist") % (logdir)
 		exit(1)
@@ -139,6 +145,7 @@ def lg(logfile,data,tostdout=1, timestamp=0):
 		data = '[' + d + '] ' + data
 	if tostdout == 1:
 		print(data)
+
 	f = open(logfile, "ab")
 	line = "%s\n" % data
 	f.write(line.encode('utf-8'))


### PR DESCRIPTION
If NFS mounted log directory is not accessible due to NFS/Network issue, SLS will exit

Fix: Retry accessing log directory after 20 seconds.