### PR TITLE
Run only BASE IO if RHOST goes down

### DIFF
--- a/go_sls.py
+++ b/go_sls.py
@@ -291,6 +291,8 @@ if s:
 	if net_or_nfs == 1:
 		os.environ['WAIT_SCENARIO'] = 'YES'
 
+network_fail = 0
+
 scen = 0
 scenario_file = "%s/SCENARIO_LIST" % os.environ['TC_OUTPUT']
 #If Scaenario file given as input
@@ -308,6 +310,10 @@ if r:
 			if len(l.split('=')) != 2:
 				line = "Wrong line number:%d  : %s" % (lnum,l)
 				lg(log, line, 0)
+				network_fail = 1
+				process.terminate()
+				os.killpg(0, signal.SIGINT)
+				cleanup(log,tlog)
 				exit(1)
 			key = l.split('=')[0]
 			val = l.split('=')[1]
@@ -345,8 +351,10 @@ if r:
 		GetFsSpace(log, tlog)
 		if network_testing == 1 and CheckNw(log, ltp_vars) == 1:	
 			lg(log, 'Network check failed, exiting...')
+			network_fail = 1
 			process.terminate()
-			exit(1)
+			os.killpg(0, signal.SIGINT)
+			break
 		time.sleep(2)
 	lg(log, "Completed all test scenario execution.", 0)
 
@@ -364,7 +372,13 @@ if r:
 	with open(MASTER_FILE, 'r') as g:
 		REPORT = json.load(g)
 	g.close()
-	REPORT['RESULTS']['STATUS'] = 'Completed'
+
+	if network_fail == 0:
+		REPORT['RESULTS']['STATUS'] = 'Completed'
+		lg(log, "Completed all test scenario execution.", 0)
+	else:
+		REPORT['RESULTS']['STATUS'] = 'ABORTED: RHOST_DOWN'
+
 	CURRENT_TIME = datetime.datetime.now()
 	REPORT['RESULTS']['RUNTIME'] = str(CURRENT_TIME - START_TIME)
 	with open(MASTER_FILE, 'w') as g:
@@ -472,6 +486,21 @@ while True:
 			if re.search(suite_iter[0], os.environ['NW2_LIST'], re.M):
 				if suite_iter[1] > 10:
 					suite_iter[1] = 10
+	
+			#If network_fail then pick skip NFS and Network tests
+			if network_fail == 1:
+				if re.search(suite_iter[0], os.environ['NW1_LIST'], re.M):
+					iline = 'Ignoring network test:%s, as RHOSTS ping failed' % test
+					lg(log, iline, 0)
+					continue
+				if re.search(suite_iter[0], os.environ['NW2_LIST'], re.M):
+					iline = 'Ignoring network test:%s, as RHOSTS ping failed' % test
+					lg(log, iline, 0)
+					continue
+				if re.search(suite_iter[0], os.environ['NFS_LIST'], re.M):
+					iline = 'Ignoring NFS test:%s, as RHOSTS ping failed' % test
+					lg(log, iline, 0)
+					continue
 			
 			test_detail = "%s(%s|%d)" % (test, suite_iter[0], suite_iter[1])
 			tests_scenario.append(test_detail)
@@ -553,8 +582,14 @@ while True:
 		GetFsSpace(log, tlog)
 		if t or n or net_or_nfs == 1:
 			if CheckNw(log, ltp_vars) == 1:
-				lg(log, 'Network check failed, exiting...')
-				break
+				network_fail = 1
+				if b or i or s:
+					lg(log, 'Network check failed, so will pick only BASE & IO tests...')
+				else:
+					lg(log, 'Network check failed, exiting...')
+					break
+			else:
+				network_fail = 0
 		time.sleep(2)
 
 	CURRENT_TIME = datetime.datetime.now()
@@ -590,7 +625,12 @@ while True:
 with open(MASTER_FILE, 'r') as g:
 	REPORT = json.load(g)
 g.close()
-REPORT['RESULTS']['STATUS'] = 'Completed'
+if network_fail == 0:
+	REPORT['RESULTS']['STATUS'] = 'Completed'
+	lg(log, "Completed full suite, Thanks for using SLS Tool", 0)
+else:
+	REPORT['RESULTS']['STATUS'] = 'ABORTED: RHOST_DOWN'
+
 REPORT['RESULTS']['RUNTIME'] = str(CURRENT_TIME - START_TIME)
 with open(MASTER_FILE, 'w') as g:
 	json.dump(REPORT, g)
@@ -600,6 +640,5 @@ fcntl.flock(lock_file, fcntl.LOCK_UN)
 
 line = "Updated STATUS to COMPLETE in REPORT.json"
 lg(log, line, 0)
-lg(log, "Completed full suite, Thanks for using SLS Tool", 0)
 os.killpg(0, signal.SIGINT)
 process.terminate() 


### PR DESCRIPTION
If RHOST goes down for some reason, instead of aborting SLS, lets continue to run BASE and IO tests