### PR TITLE
Cap NFS_TC_Iterations to < 10

### DIFF
--- a/go_sls.py
+++ b/go_sls.py
@@ -482,8 +482,9 @@ while True:
 				if suite_iter[1] > 10:
 					suite_iter[1] = 10
 			if re.search(suite_iter[0], os.environ['NFS_LIST'], re.M):
-                                if suite_iter[1] > 10:
-                                        suite_iter[1] = GetRandom(10, 1)		
+				if suite_iter[1] > 10:
+					suite_iter[1] = GetRandom(10)
+
 			
 			test_detail = "%s(%s|%d)" % (test, suite_iter[0], suite_iter[1])
 			tests_scenario.append(test_detail)
@@ -520,8 +521,8 @@ while True:
 				if suite_iter[1] > 10:
 					suite_iter[1] = 10
 			if re.search(suite_iter[0], os.environ['NFS_LIST'], re.M):
-                                if suite_iter[1] > 10:
-                                        suite_iter[1] = GetRandom(10, 1)
+				if suite_iter[1] > 10:
+					suite_iter[1] = GetRandom(10)
 
 			#Add test to test list
 			test_detail = "%s(%s|%d)" % (test, suite_iter[0], suite_iter[1])

--- a/go_sls.py
+++ b/go_sls.py
@@ -481,6 +481,9 @@ while True:
 			if re.search(suite_iter[0], os.environ['NW2_LIST'], re.M):
 				if suite_iter[1] > 10:
 					suite_iter[1] = 10
+			if re.search(suite_iter[0], os.environ['NFS_LIST'], re.M):
+                                if suite_iter[1] > 10:
+                                        suite_iter[1] = GetRandom(10, 1)		
 			
 			test_detail = "%s(%s|%d)" % (test, suite_iter[0], suite_iter[1])
 			tests_scenario.append(test_detail)
@@ -516,6 +519,9 @@ while True:
 			if re.search(suite_iter[0], os.environ['NW2_LIST'], re.M):
 				if suite_iter[1] > 10:
 					suite_iter[1] = 10
+			if re.search(suite_iter[0], os.environ['NFS_LIST'], re.M):
+                                if suite_iter[1] > 10:
+                                        suite_iter[1] = GetRandom(10, 1)
 
 			#Add test to test list
 			test_detail = "%s(%s|%d)" % (test, suite_iter[0], suite_iter[1])


### PR DESCRIPTION
Fix for issue https://github.com/ppc64le/sls-tool/issues/40

Generally the iterations are chosen dynamically b/w 1-127 for all the testcases.
Certain tests like NFS run for long and for dynamic number generated > 10, will be capped b/w 1-10 automatically to reduce lengthy run time.