### PR TITLE
pmem_fix_hackberfest_issue#37

### DIFF
--- a/common_sls.py
+++ b/common_sls.py
@@ -33,11 +33,12 @@
 #          20. GetFsSpace : Check how much free space is available on boot disk
 #          21. SetMinFree : Sets min_free_kbytes and swappiness as per SLS requirement
 #          22. CreateFS : Creates Filesystem/LVM on IO disks
-#          23. CreatePMEMFS : Creates pmem namespaces and filesystem required for IO test
-#          24. OOMKill : Kills SLS related processes if free memory goes below 10% of total memory
-#          25. ParseScenFile : Parses scenario file if SLS is executed with -r option
-#          26. GetSuiteIterations : Finds to which suite a test belongs to and decides how many iterations a test should be executed
+#          23. OOMKill : Kills SLS related processes if free memory goes below 10% of total memory
+#          24. ParseScenFile : Parses scenario file if SLS is executed with -r option
+#          25. GetSuiteIterations : Finds to which suite a test belongs to and decides how many iterations a test should be executed
+#          26. CreatePMEMFS : Creates pmem namespaces and filesystem required for IO test
 #
+
 #  SETUP:   1. Install SLS : ./install_sls.py 
 #           2. Start SLS : ./start_sls.py <options>
 #           3. Functions in common_sls.py will get called internally from above two scripts.

--- a/sls_config
+++ b/sls_config
@@ -8,6 +8,7 @@ MUST_TEST=''
 EXCLUDE_TEST='zram01.sh,zram02.sh,zram03'
 IO_DISKS=''
 IO_FS=''
+PMEM=''
 MACHINE_INFO_COMMANDS='multipath -l, df -h, cat /proc/cmdline'
 
 

--- a/start_sls.py
+++ b/start_sls.py
@@ -173,6 +173,18 @@ if i or s:
 			else:
 				lg(slog, 'IO disks will be used for IO tests')	
 			lg(slog, '------------------------------\n')
+                            PMEMDISKS = ltp_vars['PMEM']
+                            if PMEMDISKS == 'Y' or PMEMDISKS == 'yes' or PMEMDISKS == 1:
+                                lg(slog, '\nPreparing pmem devices for IO tests:\n------------------------------')
+                                fs_ret = CreatePMEMFS(slog)
+                                if fs_ret == 1:
+                                    exit(1)
+                                elif fs_ret == 2:
+                                    lg(slog, '/tmp will be used by IO tests')
+                                else:
+                                    lg(slog, 'IO pmem disks will be used for IO tests')
+                                lg(slog, '------------------------------\n')
+                        
 
 #Check MUST TESTS and EXCLUDE TESTS
 for TST in ['MUST_TEST', 'EXCLUDE_TEST']:

--- a/start_sls.py
+++ b/start_sls.py
@@ -173,17 +173,17 @@ if i or s:
 			else:
 				lg(slog, 'IO disks will be used for IO tests')	
 			lg(slog, '------------------------------\n')
-                            PMEMDISKS = ltp_vars['PMEM']
-                            if PMEMDISKS == 'Y' or PMEMDISKS == 'yes' or PMEMDISKS == 1:
-                                lg(slog, '\nPreparing pmem devices for IO tests:\n------------------------------')
-                                fs_ret = CreatePMEMFS(slog)
-                                if fs_ret == 1:
-                                    exit(1)
-                                elif fs_ret == 2:
-                                    lg(slog, '/tmp will be used by IO tests')
-                                else:
-                                    lg(slog, 'IO pmem disks will be used for IO tests')
-                                lg(slog, '------------------------------\n')
+                PMEMDISKS = ltp_vars['PMEM']
+                if PMEMDISKS == 'Y' or PMEMDISKS == 'yes' or PMEMDISKS == 1:
+                    lg(slog, '\nPreparing pmem devices for IO tests:\n------------------------------')
+                    fs_ret = CreatePMEMFS(slog)
+                    if fs_ret == 1:
+                        exit(1)
+                    elif fs_ret == 2:
+                        lg(slog, '/tmp will be used by IO tests')
+                    else:
+                        lg(slog, 'IO pmem disks will be used for IO tests')
+                        lg(slog, '------------------------------\n')
                         
 
 #Check MUST TESTS and EXCLUDE TESTS


### PR DESCRIPTION
	modified:   common_sls.py
	modified:   sls_config
	modified:   start_sls.py

Test Output:
========
```

root@sumlp51:/SLS_PYTHON ./start_sls.py -i
Parsing Arguments
Command : rm -f /var/log/sls/* Failed
Trying to umount sls related filesystems, if any...

Preparing Disks for IO tests:
------------------------------
Creating FS:xfs on Disk:/dev/sdb
mkfs.xfs -f /dev/sdb
Mounting Disk:/dev/sdb to /tmp/ltp_io0
mount /dev/sdb /tmp/ltp_io0
IO disks will be used for IO tests
------------------------------

Preparing pmem devices for IO tests:
------------------------------
region1......10G
ndctl create-namespace -r region1 -s 10G
region0......10G
ndctl create-namespace -r region0 -s 10G
region2......10G
ndctl create-namespace -r region2 -s 10G
mkfs.xfs -f /dev/pmem1 -b size=65536 -s size=512
Mounting Disk:/dev/pmem1 to /tmp/ltp_io_pmem11
mount -o dax /dev/pmem1 /tmp/ltp_io_pmem11
mkfs.ext4 -F /dev/pmem0 -b 65536
Mounting Disk:/dev/pmem0 to /tmp/ltp_io_pmem12
mount -o dax /dev/pmem0 /tmp/ltp_io_pmem12
mkfs.xfs -f /dev/pmem2 -b size=65536 -s size=512
Mounting Disk:/dev/pmem2 to /tmp/ltp_io_pmem13
mount -o dax /dev/pmem2 /tmp/ltp_io_pmem13
IO pmem disks will be used for IO tests
------------------------------

Exporting LTP Variables
Creating Log directories
Loading modules
Starting Required OS services
Log:/var/log/sls/start_sls.log
Command : systemctl  enable syslog Failed
--------------------------------------------------
Started LTP with ./start_sls.py -i
--------------------------------------------------
Please monitor HTML test logs here : sumlp51:/LOGS/SLS//SLES/5.3.18-24.24/sumlp5                                                               1/20201024.191653.509
root@sumlp51:/SLS_PYTHON 


root@sumlp54:/SLS_PYTHON ./start_sls.py -i
Parsing Arguments
Command : rm -f /var/log/sls/* Failed
Trying to umount sls related filesystems, if any...
Unmounting : /tmp/ltp_io0
Unmounting : /tmp/ltp_io1
Unmounting : /tmp/ltp_io2
Unmounting : /tmp/ltp_io_pmem11
Unmounting : /tmp/ltp_io_pmem12

Preparing Disks for IO tests:
------------------------------
Creating FS:xfs on Disk:/dev/mapper/mpathb
mkfs.xfs -f /dev/mapper/mpathb
Mounting Disk:/dev/mapper/mpathb to /tmp/ltp_io0
mount /dev/mapper/mpathb /tmp/ltp_io0
Creating FS:ext4 on Disk:/dev/mapper/mpathc
mkfs.ext4 -F /dev/mapper/mpathc
Mounting Disk:/dev/mapper/mpathc to /tmp/ltp_io1
mount /dev/mapper/mpathc /tmp/ltp_io1
Creating FS:xfs on Disk:/dev/mapper/mpathd
mkfs.xfs -f /dev/mapper/mpathd
Mounting Disk:/dev/mapper/mpathd to /tmp/ltp_io2
mount /dev/mapper/mpathd /tmp/ltp_io2
IO disks will be used for IO tests
------------------------------


Preparing pmem devices for IO tests:
------------------------------
region1......20G
ndctl create-namespace -r region1 -s 20G
region0......30G
ndctl create-namespace -r region0 -s 30G
Creating FS:xfs on Disk:/dev/pmem1
mkfs.xfs -f /dev/pmem1 -b size=65536 -s size=512
Mounting Disk:/dev/pmem1 to /tmp/ltp_io_pmem11
mount -o dax /dev/pmem1 /tmp/ltp_io_pmem11
Creating FS:ext4 on Disk:/dev/pmem0
mkfs.ext4 -F /dev/pmem0 -b 65536
Mounting Disk:/dev/pmem0 to /tmp/ltp_io_pmem12
mount -o dax /dev/pmem0 /tmp/ltp_io_pmem12
IO pmem disks will be used for IO tests
------------------------------

Exporting LTP Variables
Creating Log directories
kdump/fadump not configured
root@sumlp54:/SLS_PYTHON

```