### PR TITLE
Improving abort function

### DIFF
--- a/stop_sls.py
+++ b/stop_sls.py
@@ -91,7 +91,7 @@ while True:
 with open(MASTER_FILE, 'r') as g:
 	REPORT = json.load(g)
 
-REPORT['RESULTS']['STATUS'] = "ABORTED"
+REPORT['RESULTS']['STATUS'] = "STOPPED_BY_USER"
 with open(MASTER_FILE, "w") as g:
 	json.dump(REPORT, g)
 


### PR DESCRIPTION
Successfully tested both the ABORT methods

root@vimlp1:/SLS_PYTHON/sls-tool/sls-tool  ps -eaf |grep -i sls
root      110329       1  1 18:54 pts/0    00:00:02 python ./go_sls.py -b -i
root      120739       1  0 18:55 pts/0    00:00:00 /bin/sh /opt/ltp/runltp -I 29 -f containers -s netns_comm.sh -g /LOGS/SLS//RedHat/5.8.0-1.2020_09_09.eos.ibm.el8.ppc64le/vimlp1/20201027.185452.176/LTP_HTML_LOG/netns_comm.sh.html -C /tmp/FAILCMDFILE -T /tmp/TCONFCMDFILE -o /opt/ltp/output/netns_comm.sh_20201027185559 -l /opt/ltp/results/netns_comm.sh_20201027185559 -p
root      134503   63339  0 18:58 pts/0    00:00:00 grep -i sls
root@vimlp1:/SLS_PYTHON/sls-tool/sls-tool kill -SIGABRT  110329

root@vimlp1:/LOGS/SLS/RedHat/5.8.0-1.2020_09_09.eos.ibm.el8.ppc64le/vimlp1/20201027.185452.176 tail REPORT.json
{"RESULTS": {"PASS%": 86, "FAIL%": 0, "SKIP%": 14, "CONF%": 0, "BROK%": 0, "STATUS": "ABORTED: **STOPPED_BY_OS**"
